### PR TITLE
Renaming imported "PhotoSwipe" to all lowercase "photoswipe"

### DIFF
--- a/src/easyPhotoSwiper.js
+++ b/src/easyPhotoSwiper.js
@@ -1,5 +1,5 @@
 import $ from 'jquery'
-import PhotoSwipe from 'PhotoSwipe'
+import PhotoSwipe from 'photoswipe'
 import PhotoSwipeUIDefault from '../default-ui/photoswipe-ui-default.js'
 import queryString from 'query-string'
 


### PR DESCRIPTION
I'm not sure if `PhotoSwipe` is intentional, but I'm not able to get it to build successfully unless the package name being imported is `photoswipe` (all lower case) 

The package itself is all lowercase: https://www.npmjs.com/package/photoswipe